### PR TITLE
구글 로그인 2차 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,8 +79,8 @@ dependencies {
     // For the Firebase platform
     implementation platform ('com.google.firebase:firebase-bom:29.3.0')
     implementation 'com.google.android.gms:play-services-auth:20.2.0'
-    implementation 'com.google.firebase:firebase-auth-ktx:21.0.3'
-    implementation 'com.google.firebase:firebase-database-ktx:20.0.4'
+    implementation 'com.google.firebase:firebase-auth-ktx:21.0.4'
+    implementation 'com.google.firebase:firebase-database-ktx:20.0.5'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$kotlinx_coroutines_version"
 
     // Custom Dependencies

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,15 +32,11 @@
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.ShareRoutine.NoActionBar">
-
-
         </activity>
-
         <activity
             android:name=".ui.user.LoginActivity"
             android:exported="true"
             android:theme="@style/Theme.ShareRoutine.NoActionBar">
-
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -48,5 +44,4 @@
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/app/src/main/java/com/example/shareroutine/data/mapper/UserMapper.kt
+++ b/app/src/main/java/com/example/shareroutine/data/mapper/UserMapper.kt
@@ -1,0 +1,14 @@
+package com.example.shareroutine.data.mapper
+
+import com.example.shareroutine.data.source.realtime.model.RealtimeDBModelUser
+import com.example.shareroutine.domain.model.User
+
+object UserMapper {
+    fun fromRealtimeDBModelUserToUser(user: RealtimeDBModelUser): User {
+        return User(user.idToken, user.emailId, user.nickname)
+    }
+
+    fun fromUserToRealtimeDBModelUser(user: User): RealtimeDBModelUser {
+        return RealtimeDBModelUser(user.id, user.email, user.nickname)
+    }
+}

--- a/app/src/main/java/com/example/shareroutine/data/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/shareroutine/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,72 @@
+package com.example.shareroutine.data.repository
+
+import com.example.shareroutine.data.mapper.UserMapper
+import com.example.shareroutine.data.source.UserAuthDataSource
+import com.example.shareroutine.data.source.UserRemoteDataSource
+import com.example.shareroutine.data.source.realtime.State
+import com.example.shareroutine.di.IoDispatcher
+import com.example.shareroutine.domain.model.User
+import com.example.shareroutine.domain.repository.UserRepository
+import com.google.firebase.auth.GoogleAuthProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val remoteDataSource: UserRemoteDataSource,
+    private val auth: UserAuthDataSource,
+    @IoDispatcher private val ioDisPatcher: CoroutineDispatcher
+) : UserRepository {
+    override suspend fun insert(user: User) {
+        remoteDataSource.insert(UserMapper.fromUserToRealtimeDBModelUser(user))
+    }
+
+    override suspend fun update(user: User) {
+        remoteDataSource.update(UserMapper.fromUserToRealtimeDBModelUser(user))
+    }
+
+    override suspend fun delete(user: User) {
+        remoteDataSource.delete(UserMapper.fromUserToRealtimeDBModelUser(user))
+    }
+
+    override suspend fun fetchUser(id: String): User {
+        return when (val user = remoteDataSource.fetchUser(id)) {
+            is State.Success -> {
+                UserMapper.fromRealtimeDBModelUserToUser(user.data)
+            }
+            is State.Failed -> throw Exception(user.message)
+        }
+    }
+
+    override suspend fun signInWithGoogle(idToken: String): User = withContext(ioDisPatcher) {
+        val credential = GoogleAuthProvider.getCredential(idToken, null)
+        var user = User("", "", "")
+
+        val result = auth.getAuthResult(credential)
+        val uid = result.user?.uid!!
+        val email = result.user?.email!!
+
+        if (result.additionalUserInfo?.isNewUser == true) {
+            remoteDataSource.insert(
+                UserMapper.fromUserToRealtimeDBModelUser(
+                    User(uid, email, uid)
+                )
+            )
+        }
+        else {
+            when (val fetched = remoteDataSource.fetchUser(uid)) {
+                is State.Success -> {
+                    user = User(
+                        fetched.data.idToken,
+                        fetched.data.emailId,
+                        fetched.data.nickname)
+                }
+                is State.Failed -> {
+                    throw Exception(fetched.message)
+                }
+            }
+        }
+
+        return@withContext user
+    }
+}

--- a/app/src/main/java/com/example/shareroutine/data/source/UserAuthDataSource.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/UserAuthDataSource.kt
@@ -1,0 +1,8 @@
+package com.example.shareroutine.data.source
+
+import com.google.firebase.auth.AuthCredential
+import com.google.firebase.auth.AuthResult
+
+interface UserAuthDataSource {
+    suspend fun getAuthResult(googleAuthCredential: AuthCredential): AuthResult
+}

--- a/app/src/main/java/com/example/shareroutine/data/source/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/UserRemoteDataSource.kt
@@ -1,0 +1,12 @@
+package com.example.shareroutine.data.source
+
+import com.example.shareroutine.data.source.realtime.State
+import com.example.shareroutine.data.source.realtime.model.RealtimeDBModelUser
+
+interface UserRemoteDataSource {
+    suspend fun insert(user: RealtimeDBModelUser)
+    suspend fun update(user: RealtimeDBModelUser)
+    suspend fun delete(user: RealtimeDBModelUser)
+
+    suspend fun fetchUser(id: String): State<RealtimeDBModelUser>
+}

--- a/app/src/main/java/com/example/shareroutine/data/source/auth/UserDataSourceImplWithAuth.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/auth/UserDataSourceImplWithAuth.kt
@@ -1,0 +1,17 @@
+package com.example.shareroutine.data.source.auth
+
+import com.example.shareroutine.data.source.UserAuthDataSource
+import com.example.shareroutine.data.source.realtime.State
+import com.google.firebase.auth.AuthCredential
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class UserDataSourceImplWithAuth @Inject constructor(
+    private val auth: FirebaseAuth
+) : UserAuthDataSource {
+    override suspend fun getAuthResult(googleAuthCredential: AuthCredential): AuthResult {
+        return auth.signInWithCredential(googleAuthCredential).await()
+    }
+}

--- a/app/src/main/java/com/example/shareroutine/data/source/realtime/UserDataSourceImplWithRealtime.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/realtime/UserDataSourceImplWithRealtime.kt
@@ -1,0 +1,39 @@
+package com.example.shareroutine.data.source.realtime
+
+import com.example.shareroutine.data.source.UserRemoteDataSource
+import com.example.shareroutine.data.source.realtime.model.RealtimeDBModelUser
+import com.example.shareroutine.di.UserDatabaseRef
+import com.google.firebase.database.DatabaseReference
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class UserDataSourceImplWithRealtime @Inject constructor(
+    @UserDatabaseRef private val dbRef: DatabaseReference
+) : UserRemoteDataSource {
+    override suspend fun insert(user: RealtimeDBModelUser) {
+        dbRef.child(user.idToken).setValue(user).await()
+    }
+
+    override suspend fun update(user: RealtimeDBModelUser) {
+        val item: HashMap<String, RealtimeDBModelUser> = hashMapOf()
+        user.idToken.let { item.put(it, user) }
+
+        dbRef.updateChildren(item as Map<String, Any>).await()
+    }
+
+    override suspend fun delete(user: RealtimeDBModelUser) {
+        user.idToken.let { dbRef.child(it).removeValue().await() }
+    }
+
+    override suspend fun fetchUser(id: String): State<RealtimeDBModelUser> {
+        return try {
+            val snapshot = dbRef.child(id).get().await()
+            val user = snapshot.getValue(RealtimeDBModelUser::class.java)!!
+
+            State.success(user)
+        }
+        catch (e: Exception) {
+            State.failed(e.message!!)
+        }
+    }
+}

--- a/app/src/main/java/com/example/shareroutine/data/source/realtime/model/RealtimeDBModelUser.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/realtime/model/RealtimeDBModelUser.kt
@@ -1,0 +1,7 @@
+package com.example.shareroutine.data.source.realtime.model
+
+data class RealtimeDBModelUser(
+    var idToken: String = "",
+    var emailId: String = "",
+    var nickname: String = ""
+)

--- a/app/src/main/java/com/example/shareroutine/di/FirebaseModule.kt
+++ b/app/src/main/java/com/example/shareroutine/di/FirebaseModule.kt
@@ -1,5 +1,6 @@
 package com.example.shareroutine.di
 
+import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DatabaseReference
 import com.google.firebase.database.FirebaseDatabase
 import dagger.Module
@@ -15,8 +16,12 @@ object FirebaseModule {
 
     @Singleton
     @Provides
+    fun provideAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+
+    @Singleton
+    @Provides
     @PostDatabaseRef
-    fun providePostDatabaseRef() : DatabaseReference {
+    fun providePostDatabaseRef(): DatabaseReference {
         val db = FirebaseDatabase.getInstance(
             "https://shareroutine-default-rtdb.firebaseio.com/"
         )
@@ -42,6 +47,16 @@ object FirebaseModule {
         )
         return db.getReference("todos")
     }
+
+    @Singleton
+    @Provides
+    @UserDatabaseRef
+    fun provideUserDatabaseRef(): DatabaseReference {
+        val db = FirebaseDatabase.getInstance(
+            "https://shareroutine-default-rtdb.firebaseio.com/"
+        )
+        return db.getReference("users")
+    }
 }
 
 @Retention(AnnotationRetention.BINARY)
@@ -52,6 +67,10 @@ annotation class PostDatabaseRef
 @Qualifier
 annotation class RoutineDatabaseRef
 
-@Retention
+@Retention(AnnotationRetention.BINARY)
 @Qualifier
 annotation class TodoDatabaseRef
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class UserDatabaseRef

--- a/app/src/main/java/com/example/shareroutine/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/shareroutine/di/RepositoryModule.kt
@@ -2,15 +2,16 @@ package com.example.shareroutine.di
 
 import com.example.shareroutine.data.repository.PostRepositoryImpl
 import com.example.shareroutine.data.repository.RoutineRepositoryImpl
-import com.example.shareroutine.data.source.PostDataSource
-import com.example.shareroutine.data.source.RoutineLocalDataSource
-import com.example.shareroutine.data.source.RoutineRemoteDataSource
+import com.example.shareroutine.data.repository.UserRepositoryImpl
+import com.example.shareroutine.data.source.*
 import com.example.shareroutine.domain.repository.PostRepository
 import com.example.shareroutine.domain.repository.RoutineRepository
+import com.example.shareroutine.domain.repository.UserRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
 
 @Module
@@ -27,4 +28,12 @@ object RepositoryModule {
     @Singleton
     @Provides
     fun providePostRepository(postDataSource: PostDataSource): PostRepository = PostRepositoryImpl(postDataSource)
+
+    @Singleton
+    @Provides
+    fun provideUserRepository(
+        remote: UserRemoteDataSource,
+        auth: UserAuthDataSource,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher
+    ): UserRepository = UserRepositoryImpl(remote, auth, ioDispatcher)
 }

--- a/app/src/main/java/com/example/shareroutine/di/UserDataSourceModule.kt
+++ b/app/src/main/java/com/example/shareroutine/di/UserDataSourceModule.kt
@@ -1,0 +1,30 @@
+package com.example.shareroutine.di
+
+import com.example.shareroutine.data.source.UserAuthDataSource
+import com.example.shareroutine.data.source.UserRemoteDataSource
+import com.example.shareroutine.data.source.auth.UserDataSourceImplWithAuth
+import com.example.shareroutine.data.source.realtime.UserDataSourceImplWithRealtime
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.DatabaseReference
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UserDataSourceModule {
+
+    @Singleton
+    @Provides
+    fun provideUserDataSourceImplWithRealtime(
+        @UserDatabaseRef dbRef: DatabaseReference
+    ):
+            UserRemoteDataSource = UserDataSourceImplWithRealtime(dbRef)
+
+    @Singleton
+    @Provides
+    fun provideUserDataSourceImplWithAuth(auth: FirebaseAuth):
+            UserAuthDataSource = UserDataSourceImplWithAuth(auth)
+}

--- a/app/src/main/java/com/example/shareroutine/domain/model/User.kt
+++ b/app/src/main/java/com/example/shareroutine/domain/model/User.kt
@@ -1,0 +1,7 @@
+package com.example.shareroutine.domain.model
+
+data class User(
+    val id: String,
+    val email: String,
+    val nickname: String
+)

--- a/app/src/main/java/com/example/shareroutine/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/shareroutine/domain/repository/UserRepository.kt
@@ -1,0 +1,14 @@
+package com.example.shareroutine.domain.repository
+
+import com.example.shareroutine.domain.model.User
+import com.google.firebase.auth.AuthCredential
+
+interface UserRepository {
+    suspend fun insert(user: User)
+    suspend fun update(user: User)
+    suspend fun delete(user: User)
+
+    suspend fun fetchUser(id: String): User
+
+    suspend fun signInWithGoogle(idToken: String): User
+}

--- a/app/src/main/java/com/example/shareroutine/domain/usecase/user/FetchUserUseCase.kt
+++ b/app/src/main/java/com/example/shareroutine/domain/usecase/user/FetchUserUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.shareroutine.domain.usecase.user
+
+import com.example.shareroutine.domain.model.User
+import com.example.shareroutine.domain.repository.UserRepository
+import javax.inject.Inject
+
+class FetchUserUseCase @Inject constructor(
+    private val repository: UserRepository
+) {
+    suspend operator fun invoke(id: String): User = repository.fetchUser(id)
+}

--- a/app/src/main/java/com/example/shareroutine/domain/usecase/user/SignInUserUseCase.kt
+++ b/app/src/main/java/com/example/shareroutine/domain/usecase/user/SignInUserUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.shareroutine.domain.usecase.user
+
+import com.example.shareroutine.domain.model.User
+import com.example.shareroutine.domain.repository.UserRepository
+import javax.inject.Inject
+
+class SignInUserUseCase @Inject constructor(private val repository: UserRepository) {
+    suspend operator fun invoke(idToken: String): User {
+        return repository.signInWithGoogle(idToken)
+    }
+}

--- a/app/src/main/java/com/example/shareroutine/ui/user/LoginActivity.kt
+++ b/app/src/main/java/com/example/shareroutine/ui/user/LoginActivity.kt
@@ -1,102 +1,77 @@
 package com.example.shareroutine.ui.user
 
-
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.widget.Toast
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
 import com.example.shareroutine.MainActivity
 import com.example.shareroutine.R
-import com.example.shareroutine.data.model.UserAccount
+import com.example.shareroutine.databinding.ActivityLoginBinding
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
-import com.google.android.gms.common.SignInButton
 import com.google.android.gms.common.api.ApiException
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.GoogleAuthProvider
-import com.google.firebase.database.DatabaseReference
-import com.google.firebase.database.FirebaseDatabase
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
-    private lateinit var googleSignInBtn : SignInButton
-
-    var auth: FirebaseAuth? = null
-    val GOOGLE_REQUEST_CODE = 99
-    val TAG = "googleLogin"
-
-    private var mDatabase: DatabaseReference? = null
 
     private lateinit var googleSignInClient: GoogleSignInClient
+    private lateinit var resultLauncher: ActivityResultLauncher<Intent>
+    private lateinit var viewModel: LoginViewModel
+
+    private val binding by lazy { ActivityLoginBinding.inflate(layoutInflater) }
+
+    private val activityResultCallback = ActivityResultCallback<ActivityResult> {
+        when (it.resultCode) {
+            RESULT_OK -> it.data?.let { intent ->
+                val task = GoogleSignIn.getSignedInAccountFromIntent(intent)
+
+                try {
+                    val account = task.getResult(ApiException::class.java)!!
+                    viewModel.signIn(account.idToken!!)
+                    loginSuccess()
+                } catch (e: ApiException) {
+                    Toast.makeText(this, "로그인 실패", Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_login)
-        auth = FirebaseAuth.getInstance()
-        googleSignInBtn = findViewById(R.id.googleSignInBtn)
-        mDatabase = FirebaseDatabase.getInstance().reference
+        setContentView(binding.root)
+
+        viewModel = ViewModelProvider(this)[LoginViewModel::class.java]
+
+        initGoogleSignInClient()
+
+        resultLauncher = registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult(),
+            activityResultCallback
+        )
+
+        val btn = binding.googleSignInBtn
+
+        btn.setOnClickListener {
+            resultLauncher.launch(googleSignInClient.signInIntent)
+        }
+    }
+
+    private fun initGoogleSignInClient() {
         val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
             .requestIdToken(getString(R.string.web_client_id))
             .requestEmail()
             .build()
-        googleSignInClient = GoogleSignIn.getClient(this,gso)
-        googleSignInBtn.setOnClickListener {
-            signIn()
-        }
-    }
-    private fun signIn() {
-        val signInIntent = googleSignInClient.signInIntent
-        startActivityForResult(signInIntent, GOOGLE_REQUEST_CODE)
+
+        googleSignInClient = GoogleSignIn.getClient(this, gso)
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        // Result returned from launching the Intent from GoogleSignInApi.getSignInIntent(...);
-        if (requestCode == GOOGLE_REQUEST_CODE) {
-            val task = GoogleSignIn.getSignedInAccountFromIntent(data)
-            try {
-                // Google Sign In was successful, authenticate with Firebase
-                val account = task.getResult(ApiException::class.java)!!
-                Log.d(TAG, "firebaseAuthWithGoogle:" + account.id)
-                firebaseAuthWithGoogle(account.idToken!!)
-            } catch (e: ApiException) {
-                // Google Sign In failed, update UI appropriately
-                Log.d(TAG, "Google sign in failed")
-                Toast.makeText(this, "로그인 실패", Toast.LENGTH_LONG).show()
-            }
-        }
-    }
-    private fun firebaseAuthWithGoogle(idToken: String) {
-        val credential = GoogleAuthProvider.getCredential(idToken, null)
-        auth?.signInWithCredential(credential)
-            ?.addOnCompleteListener(this) { task ->
-                if (task.isSuccessful) {
-                    // Sign in success, update UI with the signed-in user's information
-                    Log.d("please", "로그인 성공")
-                    val user = auth!!.currentUser
-                    val account1: UserAccount = UserAccount()
-                    if (user != null) {
-                        account1.setIdToken(user.uid)
-                    }
-                    if (user != null) {
-                        account1.setEmailId(user.email)
-                    }
-                    if (user != null) {
-                        account1.setNickname(user.uid)
-                    }
-                    if (user != null) {
-                        mDatabase?.child("UserInfo")?.child(user.uid)?.setValue(account1)
-                    }
-
-
-                    loginSuccess()
-                } else {
-                    // If sign in fails, display a message to the user.
-                    Log.w("please", "signInWithCredential:failure", task.exception)
-                }
-            }
-    }
     private fun loginSuccess(){
         val intent = Intent(this,MainActivity::class.java)
         startActivity(intent)

--- a/app/src/main/java/com/example/shareroutine/ui/user/LoginViewModel.kt
+++ b/app/src/main/java/com/example/shareroutine/ui/user/LoginViewModel.kt
@@ -1,0 +1,28 @@
+package com.example.shareroutine.ui.user
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.shareroutine.di.IoDispatcher
+import com.example.shareroutine.domain.model.User
+import com.example.shareroutine.domain.usecase.user.SignInUserUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val signInUserUseCase: SignInUserUseCase
+) : ViewModel() {
+    private val _user = MutableLiveData<User>()
+    val user: LiveData<User> get() = _user
+
+    fun signIn(idToken: String) {
+        viewModelScope.launch {
+            val result = signInUserUseCase(idToken)
+            _user.postValue(result)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -7,7 +7,7 @@
     tools:context=".ui.user.LoginActivity">
 
     <com.google.android.gms.common.SignInButton
-        android:id="@+id/googleSignInBtn"
+        android:id="@+id/google_sign_in_btn"
         android:layout_width="301dp"
         android:layout_height="56dp"
         android:text="구글 로그인"
@@ -15,4 +15,5 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.3.10'
-
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
     }
 }


### PR DESCRIPTION
#40 에서 merge된 회원가입 및 로그인 코드를 프로젝트 구조에 알맞게 수정하고, 사용이 권장되지 않는 요소들을 대체하였다.

- User 도메인 모델 생성, DataSource/Repository 생성 및 LoginActivity에서 사용 가능한 ViewModel 생성
- Activity 내 코드 분리 및 아키텍처에 알맞게 분배
- deprecated된 onActivityResult 함수 제거, ActivityResultLauncher 적용