### PR TITLE
구글 로그인 오류 수정

### DIFF
--- a/app/src/main/java/com/example/shareroutine/data/mapper/UserMapper.kt
+++ b/app/src/main/java/com/example/shareroutine/data/mapper/UserMapper.kt
@@ -2,6 +2,7 @@ package com.example.shareroutine.data.mapper
 
 import com.example.shareroutine.data.source.realtime.model.RealtimeDBModelUser
 import com.example.shareroutine.domain.model.User
+import com.google.firebase.auth.FirebaseUser
 
 object UserMapper {
     fun fromRealtimeDBModelUserToUser(user: RealtimeDBModelUser): User {
@@ -10,5 +11,9 @@ object UserMapper {
 
     fun fromUserToRealtimeDBModelUser(user: User): RealtimeDBModelUser {
         return RealtimeDBModelUser(user.id, user.email, user.nickname)
+    }
+
+    fun fromFirebaseUserToUser(user: FirebaseUser): User {
+        return User(user.uid, user.email!!, user.uid)
     }
 }

--- a/app/src/main/java/com/example/shareroutine/data/source/UserAuthDataSource.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/UserAuthDataSource.kt
@@ -4,5 +4,5 @@ import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
 
 interface UserAuthDataSource {
-    suspend fun getAuthResult(googleAuthCredential: AuthCredential): AuthResult
+    suspend fun getAuthResultAsync(googleAuthCredential: AuthCredential): AuthResult?
 }

--- a/app/src/main/java/com/example/shareroutine/data/source/UserAuthDataSource.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/UserAuthDataSource.kt
@@ -1,8 +1,9 @@
 package com.example.shareroutine.data.source
 
+import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
 
 interface UserAuthDataSource {
-    suspend fun getAuthResultAsync(googleAuthCredential: AuthCredential): AuthResult?
+    suspend fun getAuthResultAsync(googleAuthCredential: AuthCredential): Task<AuthResult>
 }

--- a/app/src/main/java/com/example/shareroutine/data/source/auth/UserDataSourceImplWithAuth.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/auth/UserDataSourceImplWithAuth.kt
@@ -1,7 +1,6 @@
 package com.example.shareroutine.data.source.auth
 
 import com.example.shareroutine.data.source.UserAuthDataSource
-import com.example.shareroutine.data.source.realtime.State
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
@@ -11,7 +10,11 @@ import javax.inject.Inject
 class UserDataSourceImplWithAuth @Inject constructor(
     private val auth: FirebaseAuth
 ) : UserAuthDataSource {
-    override suspend fun getAuthResult(googleAuthCredential: AuthCredential): AuthResult {
-        return auth.signInWithCredential(googleAuthCredential).await()
+    override suspend fun getAuthResultAsync(googleAuthCredential: AuthCredential): AuthResult? {
+        return try {
+            auth.signInWithCredential(googleAuthCredential).await()
+        } catch (e: Exception) {
+            null
+        }
     }
 }

--- a/app/src/main/java/com/example/shareroutine/data/source/auth/UserDataSourceImplWithAuth.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/auth/UserDataSourceImplWithAuth.kt
@@ -1,20 +1,18 @@
 package com.example.shareroutine.data.source.auth
 
 import com.example.shareroutine.data.source.UserAuthDataSource
+import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.AuthCredential
 import com.google.firebase.auth.AuthResult
 import com.google.firebase.auth.FirebaseAuth
-import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.tasks.asDeferred
 import javax.inject.Inject
 
 class UserDataSourceImplWithAuth @Inject constructor(
     private val auth: FirebaseAuth
 ) : UserAuthDataSource {
-    override suspend fun getAuthResultAsync(googleAuthCredential: AuthCredential): AuthResult? {
-        return try {
-            auth.signInWithCredential(googleAuthCredential).await()
-        } catch (e: Exception) {
-            null
-        }
+    override suspend fun getAuthResultAsync(googleAuthCredential: AuthCredential): Task<AuthResult> {
+        return auth.signInWithCredential(googleAuthCredential)
     }
 }

--- a/app/src/main/java/com/example/shareroutine/data/source/realtime/UserDataSourceImplWithRealtime.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/realtime/UserDataSourceImplWithRealtime.kt
@@ -11,8 +11,6 @@ class UserDataSourceImplWithRealtime @Inject constructor(
     @UserDatabaseRef private val dbRef: DatabaseReference
 ) : UserRemoteDataSource {
     override suspend fun insert(user: RealtimeDBModelUser) {
-        println(user.idToken)
-
         dbRef.child(user.idToken).setValue(user).await()
     }
 

--- a/app/src/main/java/com/example/shareroutine/data/source/realtime/UserDataSourceImplWithRealtime.kt
+++ b/app/src/main/java/com/example/shareroutine/data/source/realtime/UserDataSourceImplWithRealtime.kt
@@ -11,6 +11,8 @@ class UserDataSourceImplWithRealtime @Inject constructor(
     @UserDatabaseRef private val dbRef: DatabaseReference
 ) : UserRemoteDataSource {
     override suspend fun insert(user: RealtimeDBModelUser) {
+        println(user.idToken)
+
         dbRef.child(user.idToken).setValue(user).await()
     }
 
@@ -28,9 +30,14 @@ class UserDataSourceImplWithRealtime @Inject constructor(
     override suspend fun fetchUser(id: String): State<RealtimeDBModelUser> {
         return try {
             val snapshot = dbRef.child(id).get().await()
-            val user = snapshot.getValue(RealtimeDBModelUser::class.java)!!
 
-            State.success(user)
+            if (snapshot.exists()) {
+                val user = snapshot.getValue(RealtimeDBModelUser::class.java)!!
+                State.success(user)
+            }
+            else {
+                State.failed("Snapshot doesn't exist")
+            }
         }
         catch (e: Exception) {
             State.failed(e.message!!)

--- a/app/src/main/java/com/example/shareroutine/domain/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/shareroutine/domain/repository/UserRepository.kt
@@ -8,7 +8,7 @@ interface UserRepository {
     suspend fun update(user: User)
     suspend fun delete(user: User)
 
-    suspend fun fetchUser(id: String): User
+    suspend fun fetchUser(id: String): User?
 
     suspend fun signInWithGoogle(idToken: String): User
 }

--- a/app/src/main/java/com/example/shareroutine/domain/usecase/user/InsertUserUseCase.kt
+++ b/app/src/main/java/com/example/shareroutine/domain/usecase/user/InsertUserUseCase.kt
@@ -4,8 +4,8 @@ import com.example.shareroutine.domain.model.User
 import com.example.shareroutine.domain.repository.UserRepository
 import javax.inject.Inject
 
-class FetchUserUseCase @Inject constructor(
-    private val repository: UserRepository
-) {
-    suspend operator fun invoke(id: String): User? = repository.fetchUser(id)
+class InsertUserUseCase @Inject constructor(private val repository: UserRepository) {
+    suspend operator fun invoke(user: User) {
+        return repository.insert(user)
+    }
 }

--- a/app/src/main/java/com/example/shareroutine/domain/usecase/user/SignInUserUseCase.kt
+++ b/app/src/main/java/com/example/shareroutine/domain/usecase/user/SignInUserUseCase.kt
@@ -4,7 +4,7 @@ import com.example.shareroutine.domain.model.User
 import com.example.shareroutine.domain.repository.UserRepository
 import javax.inject.Inject
 
-class SignInUserUseCase @Inject constructor(private val repository: UserRepository) {
+class AuthWithFirebaseUseCase @Inject constructor(private val repository: UserRepository) {
     suspend operator fun invoke(idToken: String): User {
         return repository.signInWithGoogle(idToken)
     }

--- a/app/src/main/java/com/example/shareroutine/ui/user/LoginActivity.kt
+++ b/app/src/main/java/com/example/shareroutine/ui/user/LoginActivity.kt
@@ -34,8 +34,10 @@ class LoginActivity : AppCompatActivity() {
 
                 try {
                     val account = task.getResult(ApiException::class.java)!!
+
                     viewModel.signIn(account.idToken!!)
-                    loginSuccess()
+                    // loginSuccess()
+
                 } catch (e: ApiException) {
                     Toast.makeText(this, "로그인 실패", Toast.LENGTH_LONG).show()
                 }

--- a/app/src/main/java/com/example/shareroutine/ui/user/LoginActivity.kt
+++ b/app/src/main/java/com/example/shareroutine/ui/user/LoginActivity.kt
@@ -36,7 +36,6 @@ class LoginActivity : AppCompatActivity() {
                     val account = task.getResult(ApiException::class.java)!!
 
                     viewModel.signIn(account.idToken!!)
-                    // loginSuccess()
 
                 } catch (e: ApiException) {
                     Toast.makeText(this, "로그인 실패", Toast.LENGTH_LONG).show()
@@ -62,6 +61,12 @@ class LoginActivity : AppCompatActivity() {
 
         btn.setOnClickListener {
             resultLauncher.launch(googleSignInClient.signInIntent)
+        }
+
+        viewModel.user.observe(this) {
+            if (it != null) {
+                loginSuccess()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/shareroutine/ui/user/LoginViewModel.kt
+++ b/app/src/main/java/com/example/shareroutine/ui/user/LoginViewModel.kt
@@ -4,25 +4,34 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.shareroutine.di.IoDispatcher
 import com.example.shareroutine.domain.model.User
-import com.example.shareroutine.domain.usecase.user.SignInUserUseCase
+import com.example.shareroutine.domain.usecase.user.AuthWithFirebaseUseCase
+import com.example.shareroutine.domain.usecase.user.FetchUserUseCase
+import com.example.shareroutine.domain.usecase.user.InsertUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val signInUserUseCase: SignInUserUseCase
+    private val authWithFirebaseUseCase: AuthWithFirebaseUseCase,
+    private val fetchUserUseCase: FetchUserUseCase,
+    private val insertUserUseCase: InsertUserUseCase
 ) : ViewModel() {
     private val _user = MutableLiveData<User>()
     val user: LiveData<User> get() = _user
 
     fun signIn(idToken: String) {
         viewModelScope.launch {
-            val result = signInUserUseCase(idToken)
-            _user.postValue(result)
+            val user = authWithFirebaseUseCase(idToken)
+
+            if (fetchUserUseCase(user.id) != null) {
+                insertUserUseCase(user)
+            }
+
+            val result = fetchUserUseCase(user.id)
+
+            _user.postValue(user)
         }
     }
 }


### PR DESCRIPTION
#41 에서 실시간 데이터베이스에 사용자 관련 정보가 저장되지 않는 오류를 해결하였다.

### 원인
`LoginViewModel`의 `signIn` 함수는 내부적으로 `viewModelScope.launch`를 통해 coroutine으로 내부 동작을 실행하는 함수이다. 그러나 기존의 코드는 signIn 함수를 호출 후 바로 `MainActivity`로 화면을 이동한 후, `LoginActivity`를 `finish`하는 `loginSuccess` 함수를 호출한다.

이때 `LoginActivity`는 자신의 `onCreate`에서 `ViewModelProvider`의 `ViewModelStoreOwner` 파라미터에 `this` 키워드로 넘겨져, `LoginViewModel`의 생명 주기 또한 `LoginActivity`를 따르게 된다. 따라서 `LoginActivity`를 `finish`할 경우 `LoginViewModel` 또한 제거되어, signIn 함수를 통해 시작된 coroutine들이 모두 취소되게 된다.

### 해결
도메인 모델 `User`를 `LiveData`로 감싸, `LoginViewModel`이 관리하도록 한다. 이후 `LoginActivity`에서 `User`를 관찰하도록 하여, `signIn` 함수가 끝나고 `User`에 값이 들어올 때 비로소 `loginSuccess`를 호출하도록 하였다.