### PR TITLE
CoroutineDispatcher 관련 작업

### DIFF
--- a/app/src/main/java/com/example/shareroutine/data/repository/PostRepositoryImpl.kt
+++ b/app/src/main/java/com/example/shareroutine/data/repository/PostRepositoryImpl.kt
@@ -3,23 +3,29 @@ package com.example.shareroutine.data.repository
 import com.example.shareroutine.data.mapper.PostMapper
 import com.example.shareroutine.data.source.PostDataSource
 import com.example.shareroutine.data.source.realtime.State
+import com.example.shareroutine.di.IoDispatcher
 import com.example.shareroutine.domain.model.Post
 import com.example.shareroutine.domain.repository.PostRepository
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import java.lang.Exception
 import javax.inject.Inject
 
-class PostRepositoryImpl @Inject constructor(private val dataSource: PostDataSource) : PostRepository {
-    override suspend fun insert(post: Post) {
+class PostRepositoryImpl @Inject constructor(
+    private val dataSource: PostDataSource,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+    ) : PostRepository {
+    override suspend fun insert(post: Post) = withContext(ioDispatcher) {
         dataSource.insert(PostMapper.mapperToRealtimeDBModelPost(post))
     }
 
-    override suspend fun update(post: Post) {
+    override suspend fun update(post: Post) = withContext(ioDispatcher) {
         dataSource.update(PostMapper.mapperToRealtimeDBModelPost(post))
     }
 
-    override suspend fun delete(post: Post) {
+    override suspend fun delete(post: Post) = withContext(ioDispatcher) {
         dataSource.delete(PostMapper.mapperToRealtimeDBModelPost(post))
     }
 

--- a/app/src/main/java/com/example/shareroutine/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/shareroutine/di/RepositoryModule.kt
@@ -22,12 +22,16 @@ object RepositoryModule {
     @Provides
     fun provideRoutineRepository(
         local: RoutineLocalDataSource,
-        remote: RoutineRemoteDataSource
-    ): RoutineRepository = RoutineRepositoryImpl(local, remote)
+        remote: RoutineRemoteDataSource,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher
+    ): RoutineRepository = RoutineRepositoryImpl(local, remote, ioDispatcher)
 
     @Singleton
     @Provides
-    fun providePostRepository(postDataSource: PostDataSource): PostRepository = PostRepositoryImpl(postDataSource)
+    fun providePostRepository(
+        postDataSource: PostDataSource,
+        @IoDispatcher ioDispatcher: CoroutineDispatcher
+    ): PostRepository = PostRepositoryImpl(postDataSource, ioDispatcher)
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/example/shareroutine/ui/community/CommunityViewModel.kt
+++ b/app/src/main/java/com/example/shareroutine/ui/community/CommunityViewModel.kt
@@ -21,8 +21,7 @@ import javax.inject.Inject
 @HiltViewModel
 class CommunityViewModel @Inject constructor(
     getPostListUseCase: GetPostListUseCase,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
-    private val _posts = getPostListUseCase().asLiveData(ioDispatcher)
+    private val _posts = getPostListUseCase().asLiveData()
     val posts: LiveData<List<Post>> get() = _posts
 }

--- a/app/src/main/java/com/example/shareroutine/ui/community/search/SearchViewModel.kt
+++ b/app/src/main/java/com/example/shareroutine/ui/community/search/SearchViewModel.kt
@@ -7,9 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
 
 @HiltViewModel
-class SearchViewModel @Inject constructor(
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
-) : ViewModel() {
+class SearchViewModel @Inject constructor() : ViewModel() {
     fun searchWithHashTag(query: String) {
         println("searchWithHashTag called with query string $query")
     }


### PR DESCRIPTION
Repository 구현체의 함수들을 `withContext(ioDispatcher)`로 감싸 I/O 관련 작업이 `Dispatchers.IO`로 전송될 수 있도록 함